### PR TITLE
[ISSUE #25]解决page.select方法中, 脚本传参时参数错误的问题

### DIFF
--- a/example/src/main/java/com/ruiyun/example/PageSelectExample.java
+++ b/example/src/main/java/com/ruiyun/example/PageSelectExample.java
@@ -1,0 +1,41 @@
+package com.ruiyun.example;
+
+import com.ruiyun.jvppeteer.core.Puppeteer;
+import com.ruiyun.jvppeteer.core.browser.Browser;
+import com.ruiyun.jvppeteer.core.page.Page;
+import com.ruiyun.jvppeteer.options.LaunchOptions;
+import com.ruiyun.jvppeteer.options.LaunchOptionsBuilder;
+import com.ruiyun.jvppeteer.options.Viewport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 页面原始select标签选择动作
+ *  
+ * @author YuChen
+ * @date 2020/10/13 14:26
+ **/
+ 
+public class PageSelectExample {
+
+    public static void main(String[] args) throws Exception {
+        ArrayList<String> arrayList = new ArrayList<>();
+        LaunchOptions options = new LaunchOptionsBuilder().withArgs(arrayList).withHeadless(false).build();
+        arrayList.add("--no-sandbox");
+        arrayList.add("--disable-setuid-sandbox");
+        Viewport viewport = new Viewport();
+        viewport.setHeight(1080);
+        viewport.setWidth(1920);
+        options.setViewport(viewport);
+        //获取当前classPath
+        String classPath = PageSelectExample.class.getResource("/").toString();
+        Browser browser = Puppeteer.launch(options);
+        Page page = browser.newPage();
+        page.goTo(classPath+"/testSelect.html");
+        List<String> cc = new ArrayList<>();
+        cc.add("3");
+        Thread.sleep(3000);
+        page.select("#select_01",cc);
+    }
+}

--- a/example/src/main/resources/testSelect.html
+++ b/example/src/main/resources/testSelect.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<select id="select_01">
+  <option value="1">Volvo</option>
+  <option value="2">Saab</option>
+  <option value="3">Opel</option>
+  <option value="4">41</option>
+</select>
+  
+</body>
+</html>

--- a/src/main/java/com/ruiyun/jvppeteer/core/page/JSHandle.java
+++ b/src/main/java/com/ruiyun/jvppeteer/core/page/JSHandle.java
@@ -36,11 +36,14 @@ public class JSHandle {
     }
 
     public Object evaluate(String pageFunction, List<Object> args) {
-        if(args != null){
-            args = new ArrayList<>();
-        }
-        args.add(this);
-        return this.executionContext().evaluate(pageFunction, args);
+//        if(args != null){
+//            args = new ArrayList<>();
+//        }
+//        args.add(this);
+        List<Object> finArgs = new ArrayList<>();
+        finArgs.add(this);
+        finArgs.addAll(args);
+        return this.executionContext().evaluate(pageFunction, finArgs);
     }
 
     public Object evaluateHandle(String pageFunction, List<Object> args) {


### PR DESCRIPTION
#25

```
        ArrayList<String> arrayList = new ArrayList<>();
        LaunchOptions options = new LaunchOptionsBuilder().withArgs(arrayList).withHeadless(false).build();
        arrayList.add("--no-sandbox");
        arrayList.add("--disable-setuid-sandbox");
        Viewport viewport = new Viewport();
        viewport.setHeight(1080);
        viewport.setWidth(1920);
        options.setViewport(viewport);
        //获取当前classPath
        String classPath = PageSelectExample.class.getResource("/").toString();
        Browser browser = Puppeteer.launch(options);
        Page page = browser.newPage();
        page.goTo(classPath+"/testSelect.html");
        List<String> cc = new ArrayList<>();
        cc.add("3");
        Thread.sleep(3000);
        page.select("#select_01",cc);
```
如上所示,在使用select(selector,...option)进行原生select标签的选择option操作时, 抛出了异常:
`Exception in thread "main" com.ruiyun.jvppeteer.exception.ProtocolException: Evaluation failed: TypeError: Cannot read property 'includes' of undefined`

初步跟踪发现JSHandle中的evaluate方法可能有问题, 导致多参数时会出现参数无法传入脚本的问题

没有进行其他测试,  如果不对请忽略  :)
