### PR TITLE
修复runners不断增加,BrowserRunner类中的close()方法并不会移除runners列表,最终oom的bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,4 +118,3 @@
 - [2021-03-06 修正DefaultBrowserListener中变量名mothod为method](https://github.com/fanyong920/jvppeteer/commit/a2247ec0d3272bc0f2da823ce620bb36d447f102)
 - [INF:修改Page类以及引用的Example中onDialg方法名拼写错误; 增加Page扩展类PageExtend](https://github.com/fanyong920/jvppeteer/commit/60c8f74a5f04de1f90bd193a655e965dabc35b22)
 - [INF: Page扩展类修改，增加获取页面文本](https://github.com/fanyong920/jvppeteer/commit/65a5427d5a57bbf09632e9df46ceb76a56a55e14)
-

--- a/src/main/java/com/ruiyun/jvppeteer/core/browser/BrowserRunner.java
+++ b/src/main/java/com/ruiyun/jvppeteer/core/browser/BrowserRunner.java
@@ -191,8 +191,16 @@ public class BrowserRunner extends EventEmitter implements AutoCloseable {
      * 强制结束浏览器进程
      */
     public void destroyForcibly() {
-        if (process != null && process.isAlive()) {
-            process.destroyForcibly();
+        try {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+        } finally {
+            //必须删除,防止runners中的BrowserRunner对象一直疯涨,最终oom
+            runners.remove(this);
+            if (listeners.size() > 0) {
+                listeners.clear();
+            }
         }
     }
 


### PR DESCRIPTION
在windows 10(开发和使用环境,其他系统不知道有没有这个问题)使用中,长时间运行jvppeteer构建的应用，出现oom,经查，是由于BrowserRunner类中的close()方法不能执行,因此并不会移除runners列表中当前被关闭的对象,从而得到一个超长的runners列表, 最终oom,程序崩溃。