### PR TITLE
Provides basic support for Unix-like systems other than Mac/Linux

### DIFF
--- a/src/main/java/com/ruiyun/jvppeteer/cdp/core/BrowserFetcher.java
+++ b/src/main/java/com/ruiyun/jvppeteer/cdp/core/BrowserFetcher.java
@@ -528,7 +528,7 @@ public class BrowserFetcher {
     private Path copyShellFile(String path) throws IOException {
         Path tempDirectory = Paths.get(FileUtil.createProfileDir(SHELLS_PREFIX));
         Path shellPath = tempDirectory.resolve(path);
-        if (Helper.isMac() || Helper.isLinux()) {
+        if (Helper.isUnixLike()) {
             Files.createFile(shellPath, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
         } else if (Helper.isWindows()) {
             Files.createFile(shellPath);

--- a/src/main/java/com/ruiyun/jvppeteer/cdp/core/BrowserRunner.java
+++ b/src/main/java/com/ruiyun/jvppeteer/cdp/core/BrowserRunner.java
@@ -113,12 +113,12 @@ public class BrowserRunner {
             }
             Process exec;
             String command;
-            if (Helper.isLinux() || Helper.isMac()) {
+            if (Helper.isUnixLike()) {
                 command = "kill -9 " + pid;
                 exec = Runtime.getRuntime().exec(new String[]{"/bin/sh", "-c", command});
             } else {
-                    command = "cmd.exe /c taskkill /pid " + pid + " /F /T ";
-                    exec = Runtime.getRuntime().exec(command);
+                command = "cmd.exe /c taskkill /pid " + pid + " /F /T ";
+                exec = Runtime.getRuntime().exec(command);
             }
             try {
                 if (Objects.nonNull(exec)) {

--- a/src/main/java/com/ruiyun/jvppeteer/launch/BrowserLauncher.java
+++ b/src/main/java/com/ruiyun/jvppeteer/launch/BrowserLauncher.java
@@ -80,7 +80,6 @@ public abstract class BrowserLauncher {
         FetcherOptions fetcherOptions = new FetcherOptions();
         fetcherOptions.setProduct(this.product);
         fetcherOptions.setCacheDir(this.cacheDir);
-        BrowserFetcher browserFetcher = new BrowserFetcher(fetcherOptions);
         /*指定了启动路径，则启动指定路径的chrome*/
         if (StringUtil.isNotEmpty(preferredExecutablePath)) {
             boolean assertDir = FileUtil.assertExecutable(Paths.get(preferredExecutablePath).normalize().toAbsolutePath().toString());
@@ -100,6 +99,7 @@ public abstract class BrowserLauncher {
                 return preferredExecutablePath;
             }
         }
+        BrowserFetcher browserFetcher = new BrowserFetcher(fetcherOptions);
         /*指定了首选版本*/
         if (StringUtil.isNotEmpty(preferredRevision)) {
             RevisionInfo revisionInfo = browserFetcher.revisionInfo(preferredRevision.replace("stable_", ""));
@@ -289,7 +289,7 @@ public abstract class BrowserLauncher {
         }
         try {
             if (pid == -1) {
-                pid = Helper.getPidForLinuxOrMac(process);
+                pid = Helper.getPidForUnixLike(process);
             }
         } catch (Exception e) {
             LOGGER.error("get browser pid error by reflection: ", e);

--- a/src/main/java/com/ruiyun/jvppeteer/util/FileUtil.java
+++ b/src/main/java/com/ruiyun/jvppeteer/util/FileUtil.java
@@ -101,7 +101,7 @@ public class FileUtil {
             if (parent != null && !Files.exists(parent)) {
                 createDirs(parent);
             }
-            if (Helper.isMac() || Helper.isLinux()) {
+            if (Helper.isUnixLike()) {
                 Files.createFile(path1, PosixFilePermissions.asFileAttribute(rwxrwxrwx));
             } else if (Helper.isWindows()) {
                 Files.createFile(path1);
@@ -110,7 +110,7 @@ public class FileUtil {
     }
 
     public static void createDirs(Path path) throws IOException {
-        if (Helper.isMac() || Helper.isLinux()) {
+        if (Helper.isUnixLike()) {
             Files.createDirectories(path, PosixFilePermissions.asFileAttribute(rwxrwxrwx));
         } else if (Helper.isWindows()) {
             Files.createDirectories(path);

--- a/src/main/java/com/ruiyun/jvppeteer/util/Helper.java
+++ b/src/main/java/com/ruiyun/jvppeteer/util/Helper.java
@@ -255,6 +255,8 @@ public class Helper {
         return platform().contains("mac");
     }
 
+    public static boolean isUnixLike() { return !isWindows() && new File("/bin/sh").canExecute(); }
+
     public static String join(String root, String... args) {
         return java.nio.file.Paths.get(root, args).toString();
     }
@@ -427,9 +429,9 @@ public class Helper {
      * @throws NoSuchFieldException   field not found
      * @throws IllegalAccessException illegal access
      */
-    public static long getPidForLinuxOrMac(Process process) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+    public static long getPidForUnixLike(Process process) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
         long pid = -1;
-        if (Helper.isMac() || Helper.isLinux()) {
+        if (Helper.isUnixLike()) {
             String version = System.getProperty("java.version");
             double jdkVersion = Double.parseDouble(version.substring(0, 3));
             Class<?> clazz;


### PR DESCRIPTION
With this patch, I can create a PDF using jvppeteer on a FreeBSD system by explicitly setting the chrome binary

```
LaunchOptions.Builder launchOptionsBuilder = LaunchOptions.builder();
launchOptionsBuilder.executablePath("/usr/local/bin/chrome");
browser = Puppeteer.launch(launchOptionsBuilder.build());
```

There is 2 parts of that patch: 

1. In BrowserLauncher.java, we move the `BrowserFetcher browserFetcher = new BrowserFetcher(fetcherOptions);` line below the test checking for an explicit `preferredExecutablePath`. Without that, the test is never reached because new BrowserFetcher() fails with an exception for unknown platforms. With this change alone, a browser can start on FreeBSD.
2. a new helper `Helper.isUnixLike()` is created to detect all unix-like oses (BSD, Solaris, etc) in addition to Mac and Linux. This is needed for example to properly kill the browser: the old code would consider all platform except Mac and Solaris as Windows, and try to kill the chrome binary using `cmd.exe` on FreeBSD.